### PR TITLE
Update the runtime

### DIFF
--- a/org.sdrangel.SDRangel.yaml
+++ b/org.sdrangel.SDRangel.yaml
@@ -17,6 +17,14 @@ finish-args:
   - --filesystem=xdg-documents
 cleanup-commands:
   - /app/cleanup-BaseApp.sh
+  - mkdir -p ${FLATPAK_DEST}/lib/ffmpeg
+add-extensions:
+  org.freedesktop.Platform.ffmpeg-full:
+    directory: lib/ffmpeg
+    add-ld-path: .
+    version: '22.08'
+    autodownload: true
+    autodelete: false
 
 modules:
   - shared-modules/linux-audio/fftw3f.json

--- a/org.sdrangel.SDRangel.yaml
+++ b/org.sdrangel.SDRangel.yaml
@@ -1,9 +1,9 @@
 app-id: org.sdrangel.SDRangel
 runtime: org.kde.Platform
-runtime-version: 5.15-21.08
+runtime-version: 5.15-22.08
 sdk: org.kde.Sdk
 base: io.qt.qtwebengine.BaseApp
-base-version: 5.15-21.08
+base-version: 5.15-22.08
 command: sdrangel
 rename-desktop-file: sdrangel.desktop
 rename-icon: sdrangel_icon


### PR DESCRIPTION
Still WIP, one plugin does not work:
`2022-09-23 17:06:39.515 (W) PluginManager::loadPluginsDir: Cannot load library /app/lib/sdrangel/plugins/libmodatv.so: (/app/lib/libopencv_videoio.so.406: undefined symbol: avformat_get_mov_video_tags, version LIBAVFORMAT_59)`

It is possible that the `avformat_get_mov_video_tags()` ffmpeg function got removed from the newer runtime for some reason (legal issues?), however I am not sure.