### PR TITLE
Set ARCH_OPT to nehalem

### DIFF
--- a/org.sdrangel.SDRangel.yaml
+++ b/org.sdrangel.SDRangel.yaml
@@ -418,6 +418,10 @@ modules:
     buildsystem: cmake-ninja
     build-options:
       cxxflags: -fpermissive
+      arch:
+        x86_64:
+          config-opts:
+            - -DARCH_OPT=nehalem
     config-opts:
       - -Wno-dev
       - -DCMAKE_BUILD_TYPE=RelWithDebInfo


### PR DESCRIPTION
For compatibility with older CPUs.

Closes #63.