### PR TITLE
Reword the udev rules section in metainfo

### DIFF
--- a/org.sdrangel.SDRangel.metainfo.xml
+++ b/org.sdrangel.SDRangel.metainfo.xml
@@ -24,7 +24,7 @@
   </description>
   <screenshots>
     <screenshot type="default">
-      <image type="source">https://dashboard.snapcraft.io/site_media/appmedia/2024/03/SDRangelSID-1711125217.png</image>
+      <image type="source">https://raw.githubusercontent.com/flathub/org.sdrangel.SDRangel/refs/heads/master/screenshot.png</image>
     </screenshot>
   </screenshots>
   <url type="homepage">https://www.sdrangel.org</url>


### PR DESCRIPTION
Some of the udev rules are now part of the upstream systemd/udevd hwdb.