### PR TITLE
Remove udev rules note from AppStream description

### DIFF
--- a/org.sdrangel.SDRangel.metainfo.xml
+++ b/org.sdrangel.SDRangel.metainfo.xml
@@ -15,11 +15,6 @@
       It has native support for Airspy, Airspy HF, Airspy Discovery, FUNcube, HackRF, KiwiSDR, LimeSDR, LimeSDR Mini, LimeRFE, Perseus, PlutoSDR, RTL-SDR,
       USRP B210, XTRX, and more devices via Soapy and audio interfaces.
     </p>
-    <p>
-      Please note that the SDRangel Flatpak requires udev rules for most SDR devices to be installed. Many of these should already be part of your system,
-      but if your SDR device does not work, you will have to install the tools for your SDR via regular package manager followed by system reboot before
-      using SDRangel.
-    </p>
   </description>
   <screenshots>
     <screenshot type="default">


### PR DESCRIPTION
Almost all the SDR udev rules were already upstreamed months ago and it is now only a matter of time before they are be available in most distributions, so this (possibly confusing) note should no longer be needed.