### PR TITLE
Re-enable sdrangel x-checker-data

### DIFF
--- a/org.sdrangel.SDRangel.yaml
+++ b/org.sdrangel.SDRangel.yaml
@@ -476,10 +476,10 @@ modules:
       - type: archive
         url: https://github.com/f4exb/sdrangel/archive/refs/tags/v7.22.8.tar.gz
         sha256: 3a3114a4dc26a880c4469a997c135c3a1efaae0f4af44f76002d98eabfc178be
-        #x-checker-data:
-        #  type: anitya
-        #  project-id: 14479
-        #  url-template: https://github.com/f4exb/sdrangel/archive/refs/tags/v$version.tar.gz
+        x-checker-data:
+          type: anitya
+          project-id: 14479
+          url-template: https://github.com/f4exb/sdrangel/archive/refs/tags/v$version.tar.gz
       - type: shell
         commands:
           - sed -e 's|/usr/|/app/|g' -i cmake/Modules/FindSerialDV.cmake


### PR DESCRIPTION
This reverts commit e7be044af3d408c5f86a9f12e0dcbf5a46bc9235.

This will probably break the aarch64 build again (see #114), but since the upstream developer was not able to find out what causes this issue, blocking new upstream releases is not a good solution.