### PR TITLE
Remove mbelib

### DIFF
--- a/org.sdrangel.SDRangel.yaml
+++ b/org.sdrangel.SDRangel.yaml
@@ -183,15 +183,6 @@ modules:
         url: https://github.com/f4exb/cm256cc.git
         commit: da87adbe3e583877870cb159d37e0456549b2c29
 
-  - name: mbelib
-    buildsystem: cmake-ninja
-    config-opts:
-      - -Wno-dev
-    sources:
-      - type: archive
-        url: https://github.com/szechyjs/mbelib/archive/refs/tags/v1.3.0.tar.gz
-        sha256: 5a2d5ca37cef3b6deddd5ce8c73918f27936c50eb0e63b27e4b4fc493310518d
-
   - name: serialdv
     buildsystem: cmake-ninja
     config-opts:
@@ -204,7 +195,6 @@ modules:
   - name: dsdcc
     buildsystem: cmake-ninja
     config-opts:
-      - -DUSE_MBELIB=ON
       - -Wno-dev
     sources:
       - type: archive


### PR DESCRIPTION
Unmaintained and potentially problematic license. Remove it for now, may be replaced with a better fork in the future.