### PR TITLE
EOL the Flatpak

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+  "end-of-life": "This Flatpak is end-of-life. Please consider using the non-Flatpak version of SDRangel."
+}


### PR DESCRIPTION
Maintaining this Flatpak has turned out to be much harder than I thought, and since my time is unfortunately quite limited these days, I am not able to take proper care of it.

SDRangel has just too many bugs and weird glitches. Its build system builds with `-march=native` even if there is a build architecture specified and there is no easy way to override it. This results in crashes on "invalid opcode" in random parts of SDRangel. Very hard to debug. Even harder to fix.

Using newer KDE runtime causes SDRangel to crash on startup with "invalid opcode". Again, something that I was not able to fix.

And recent SDRangel versions fail to build with a [strange linker error](https://github.com/flathub/org.sdrangel.SDRangel/pull/170#issuecomment-3904223000).

I give up. Sorry.

/cc @xylo04 @yakushabb